### PR TITLE
Auto Label Issues for GSSoC 21

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,13 @@
+name: Labeling new issue
+on:
+  issues:
+    types: ['opened', 'edited']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: false
+          labels-synonyms: '{"GSSOC21":["gssoc21","GSSOC21","gssoc 21","GSSOC 21","GSSoC 21"]}'


### PR DESCRIPTION
This github action will auto label issues for GSSOC 21


The action will check for similar permutations of GSSOC 21 as specified in the .yml file and label those issues appropriately as GSSOC21